### PR TITLE
fix liquid tag url for post title

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ layout: default
                     </div>
                     <div class="panel-body">
                             {% for post in site.posts %}
-                                <h3><a href="{{ site.baseurl }}/{{ post.url }}">{{ post.title }}</a></h3>
+                                <h3><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h3>
                                 {{ post.excerpt }}
                                 <p class="author">
                                 <span class="date">Posted on {{ post.date | date: '%B %d, %Y' }} by {{ post.author }}</span>


### PR DESCRIPTION
Hey Nick,

I was playing around with the website again, today, to make sure everything was running smoothly and I had seen that I had left a backslash in the liquid tags on the index page. 

It is now **fixed**.