### PR TITLE
Drawer for apps

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -60,10 +60,17 @@
                     <li>
                         <a href="{{ site.baseurl }}/blog.html">Blog</a>
                     </li>
-                    <li>
-                        <a href="{{ site.baseurl }}/alert.html">ALERT</a>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Apps <b class="caret"></b></a>
+                        <ul class="dropdown-menu">
+                            <li>
+                                <a href="{{ site.baseurl }}/alert.html">ALERT</a>
+                            </li>
+                            <li>
+                                <a href="https://reichlab.github.io/flusight">Flusight</a>
+                            </li>
+                        </ul>
                     </li>
-
                 </ul>
             </li>
             </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2487306/20635626/6bfed83a-b32d-11e6-8b1b-800ac3e46412.png)

Looks like the above image.
Should the ALERT link be changed to that of the [web app](http://iddynamics.jhsph.edu/apps/shiny/ALERT/)?