### PR TITLE
Randomize the list of team members on the people page

### DIFF
--- a/_plugins/people.rb
+++ b/_plugins/people.rb
@@ -7,15 +7,13 @@ module People
   class PeopleGen < Jekyll::Generator
     def generate(site)
       team_data = YAML.load_file File.join('_data', 'team.yml')
-      # randomize the array of team members
-      team_data.shuffle!
+      # split alumni and current members into separate arrays
+      alumni = team_data.select {|p| p.fetch('type', '').downcase == 'alumni'}
+      current_members = team_data - alumni
 
       people = site.pages.detect { |page| page.name == 'people.html' }
-      people.data['members'] = team_data.map { |tm| parse_member_entry(tm, site.config['baseurl']) }
-      uniq_types = people.data['members'].map { |tm| tm['type'] }.uniq.sort
-      # Keep 'default' at top
-      uniq_types.insert(0, uniq_types.delete_at(uniq_types.index('default')))
-      people.data['types'] = uniq_types
+      people.data['current_members'] = current_members.shuffle!
+      people.data['alumni'] = alumni
     end
 
     def get_full_url(url, base)

--- a/_plugins/people.rb
+++ b/_plugins/people.rb
@@ -7,6 +7,8 @@ module People
   class PeopleGen < Jekyll::Generator
     def generate(site)
       team_data = YAML.load_file File.join('_data', 'team.yml')
+      # randomize the array of team members
+      team_data.shuffle!
 
       people = site.pages.detect { |page| page.name == 'people.html' }
       people.data['members'] = team_data.map { |tm| parse_member_entry(tm, site.config['baseurl']) }

--- a/people.html
+++ b/people.html
@@ -51,6 +51,9 @@ layout: default
 <div class="columns">
   <div class="column col-12">
     <h2>People</h2>
+    <p>Current and former members of the Reich Lab are shown below in a random order
+      that is shuffled every day.
+    </p>
   </div>
 
     {% for member in page.members %}

--- a/people.html
+++ b/people.html
@@ -51,67 +51,63 @@ layout: default
 <div class="columns">
   <div class="column col-12">
     <h2>People</h2>
-    <p>Current and former members of the Reich Lab are shown below in a random order
+    <p>Current members of the Reich Lab are shown below in a random order
       that is shuffled every day.
     </p>
   </div>
 
-    {% for member in page.members %}
-      {% if member.type != "Alumni" %}
-        <div class="column col-12">
-          <div class="card-people columns">
-            <div class="card-image column col-3 col-sm-12">
+    {% for member in page.current_members %}
+      <div class="column col-12">
+        <div class="card-people columns">
+          <div class="card-image column col-3 col-sm-12">
+            <div class="img-people" style="background-image: url({{ member.image }});">
+            </div>
+          </div>
+          <div class="column col-9 col-sm-12">
+            <div class="card-header">
+              <h4 class="card-title">{{ member.name }}</h4>&nbsp;&nbsp;
+              <h6 class="card-subtitle show-sm">{{ member.role }}</h6>
+              <h6 class="card-subtitle-inline hide-sm">{{ member.role }}</h6>
+            </div>
+            <div class="card-body">
+              {{ member.description }}
+            </div>
+            <div class="card-footer">
+              {% for link in member.links %}
+                <a href="{{ link.url }}" id="link-container">
+                  <span class="{{ link.name }}" id="link"></span>
+                </a>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+  {% endfor %}
+  <div class="column col-12">
+    <h3 class="people-type">Alumni</h3>
+  </div>
+  <div class="columns">
+    {% for member in page.alumni %}
+      <div class="alumni-container">
+          <div class="card-people alumni-card">
+            <div class="card-image">
               <div class="img-people" style="background-image: url({{ member.image }});">
               </div>
-            </div>
-            <div class="column col-9 col-sm-12">
-              <div class="card-header">
-                <h4 class="card-title">{{ member.name }}</h4>&nbsp;&nbsp;
-                <h6 class="card-subtitle show-sm">{{ member.role }}</h6>
-                <h6 class="card-subtitle-inline hide-sm">{{ member.role }}</h6>
               </div>
-              <div class="card-body">
+                <div class="card-header">
+                  <h4 class="card-title">{{ member.name }}</h4>
+                  {% for link in member.links %}
+                    <a href="{{ link.url }}" target="_blank" id="alumni-link-container">
+                      <span class="flaticon-foreign" id="alumni-link"></span>
+                    </a>
+                  {% endfor %}
+                  <br>
+                  <h6 class="card-subtitle-inline">{{ member.role }}</h6>
+                <div class="card-body">
                 {{ member.description }}
-              </div>
-              <div class="card-footer">
-                {% for link in member.links %}
-                  <a href="{{ link.url }}" id="link-container">
-                    <span class="{{ link.name }}" id="link"></span>
-                  </a>
-                {% endfor %}
               </div>
             </div>
           </div>
         </div>
-      {% endif %}
-  {% endfor %}
-  <div class="column col-12">    
-    <h3 class="people-type">Alumni</h3>
-  </div>
-  <div class="columns">
-    {% for member in page.members %}
-        {% if member.type == "Alumni" %}
-            <div class="alumni-container">
-                <div class="card-people alumni-card">
-                  <div class="card-image">
-                    <div class="img-people" style="background-image: url({{ member.image }});">
-                    </div>
-                    </div>
-                      <div class="card-header">
-                        <h4 class="card-title">{{ member.name }}</h4>
-                        {% for link in member.links %}
-                          <a href="{{ link.url }}" target="_blank" id="alumni-link-container">
-                            <span class="flaticon-foreign" id="alumni-link"></span>
-                          </a>
-                        {% endfor %}
-                        <br>
-                        <h6 class="card-subtitle-inline">{{ member.role }}</h6>
-                      <div class="card-body">
-                      {{ member.description }}
-                    </div>
-                  </div>
-                </div>    
-              </div>
-      {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
This is a low-friction way to shuffle the list of team members on [https://reichlab.io/people](https://reichlab.io/people)

The trade-off is that the order will change when the site is rebuilt but not when the page is refreshed.

If we want the lab's leaders to always be at the top, that should be do-able with a few more lines of code.