### PR TITLE
fix yaml format for Ben's team entry

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -32,7 +32,7 @@
     - name: flaticon-laptop-1
       url: "https://www.evanlray.com"
 
-  - name: Benjamin Rogers
+- name: Benjamin Rogers
   role: Research Faculty
   description: |
     Ben is a Research Assistant Professor and Lecturer of Biostatistics at UMass-Amherst. 


### PR DESCRIPTION
The website build broke yesterday and I think it was because the YAML was incorrectly formatted where there were some spaces before the start of Ben's entry. This commit fixes that.