### PR TITLE
(example of Netlify image previews) ignore netlify folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 .envrc
 .env
+# Local Netlify folder
+.netlify


### PR DESCRIPTION
Resolves #175 

This small change is meant to demonstrate the Netlify previews. Note that there are two preview  comments on this PR because I accidentally configured two reichlab.io sites in Netlify.

I've deleted one of the sites, so future PRs will have a single preview. The site with the 👎 reaction is the deleted one, and that preview link no longer works.

After chatting with @nickreich, we agreed that our eventual goal is switching site hosting from GitHub pages to Netlify, so we'll no longer need a "shadow" Netlify deployment just to get the site previews. We'll schedule some time to do that.

Additional background: [the Netlify setup that makes this work](https://reichlab.atlassian.net/wiki/spaces/RLD/pages/16482320/Netlify+Add+PR+Preview+for+Sites+on+GitHub+Pages#Directions-for-setting-up-option-2-above).

