### PR TITLE
Use Netlify for site previews but not for site hosting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "_site" # where the site is built
+
+[context.production]
+  command = "echo 'Skipping production build'"
+
+[context.deploy-preview]
+  command = "bundle exec rake collect && bundle exec rake build"


### PR DESCRIPTION
When we set up Netlify-based previews for the reichlab.io last year, I never investigated how to stop Netlify from publishing a version of the site at https://reichlab.netlify.app/ (it just hangs around silently, triggered by merges)

This commit tries out some netlify.toml settings to see if we can prevent deployments to netlify.app (reichlab site is hosted on GitHub pages).

The build command is the same one defined in `reichlab.io` Netlify site.

![image](https://github.com/user-attachments/assets/7a5a8525-180d-4a83-ad9a-60dbf4ed76b6)
