### PR TITLE
Add Plausible script to track websites

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,3 +54,10 @@
 
 <meta itemprop="name" content="{% if page.title %}{{ page.title | xml_escape }}{% else %}{{ site.title | xml_escape }}{% endif %}">
 <meta itemprop="description" content="{% if page.description %}{{ page.description | xml_escape }}{% else %}{{ site.description | xml_escape }}{% endif %}">
+
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-DOosbUzSYYO66nV9P5iOt.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>


### PR DESCRIPTION
Will be used for all websites with the same reichlab.io base, including the dashboards.